### PR TITLE
Code refactor. Use SDK 1.3.0+202

### DIFF
--- a/linear.py
+++ b/linear.py
@@ -29,10 +29,11 @@ import poptorch
 
 in_dim = 2048
 out_dim = 2048
-training_batch_size = 1
+training_batch_size = 2
+gradient_accumulation = 4
+replication_factor = 2
 training_ipu_step_size = 1
-gradient_accumulation = 8
-replication_factor = 16
+
 training_combined_batch_size = training_batch_size * training_ipu_step_size * gradient_accumulation * replication_factor
 
 torch.manual_seed(1024)
@@ -52,13 +53,17 @@ class Model(nn.Module):
 
 model = Model()
 
+opts = poptorch.Options()
+opts.deviceIterations(training_ipu_step_size)
+opts.replicationFactor(replication_factor)
+opts.anchorMode(poptorch.AnchorMode.All)
+opts.Training.gradientAccumulation(gradient_accumulation)
+
 print('torch model(x) --------------------------------------------------------')
 torch_out = model(x)
 print(torch_out)
 print('torch model(x) --------------------------------------------------------')
-train_model = poptorch.trainingModel(model, training_ipu_step_size,
-                                     gradient_accumulation=gradient_accumulation,
-                                     replication_factor=replication_factor,
+train_model = poptorch.trainingModel(model, options=opts,
                                      loss=nn.MSELoss(reduction="mean"))
 
 for i in range(1):

--- a/lstm.py
+++ b/lstm.py
@@ -4,12 +4,13 @@ import numpy as np
 import os
 import poptorch
 
-input_size = 1600
-hidden_size = 1600
-training_batch_size = 8
-time_seq = 500
+input_size = 16
+hidden_size = 16
+training_batch_size = 1
+time_seq = 50
 training_ipu_step_size = 1
 replication_factor = 1
+
 training_combined_batch_size = training_batch_size * training_ipu_step_size * replication_factor
 
 x = torch.randn(time_seq, training_combined_batch_size, input_size)
@@ -27,8 +28,12 @@ class Model(nn.Module):
 
 
 model = Model()
-train_model = poptorch.trainingModel(model, training_ipu_step_size,
-                                     replication_factor=replication_factor,
+
+opts = poptorch.Options()
+opts.deviceIterations(training_ipu_step_size)
+opts.replicationFactor(replication_factor)
+
+train_model = poptorch.trainingModel(model, options=opts,
                                      loss=nn.MSELoss(reduction="mean"))
 
 for i in range(1):


### PR DESCRIPTION
1. 修改代码，适配sdk1.3.0+202
2.linear.py中添加opts.anchorMode(poptorch.AnchorMode.All)用于把output的结果全部返回，以便和cpu端计算结果匹配。
3.lstm.py跑不过原因主要是单颗IPU目前无法跑这么大的配置，把参数改小可以通过。